### PR TITLE
Propagate diagonal dirty bit set to every routine touching xmats

### DIFF
--- a/auxiliary/d_aux_lib.c
+++ b/auxiliary/d_aux_lib.c
@@ -76,6 +76,13 @@
 // insert element into strmat
 void blasfeo_dgein1(double a, struct blasfeo_dmat *sA, int ai, int aj)
 	{
+
+	if (ai==aj)
+		{
+		// invalidate stored inverse diagonal
+		sA->use_dA = 0;
+		}
+
 	int lda = sA->m;
 	double *pA = sA->pA + ai + aj*lda;
 	pA[0] = a;
@@ -115,6 +122,9 @@ double blasfeo_dvecex1(struct blasfeo_dvec *sx, int xi)
 // set all elements of a strmat to a value
 void blasfeo_dgese(int m, int n, double alpha, struct blasfeo_dmat *sA, int ai, int aj)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int lda = sA->m;
 	double *pA = sA->pA + ai + aj*lda;
 	int ii, jj;
@@ -145,6 +155,9 @@ void blasfeo_dvecse(int m, double alpha, struct blasfeo_dvec *sx, int xi)
 // insert a vector into diagonal
 void blasfeo_ddiain(int kmax, double alpha, struct blasfeo_dvec *sx, int xi, struct blasfeo_dmat *sA, int ai, int aj)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int lda = sA->m;
 	double *pA = sA->pA + ai + aj*lda;
 	double *x = sx->pa + xi;
@@ -159,6 +172,9 @@ void blasfeo_ddiain(int kmax, double alpha, struct blasfeo_dvec *sx, int xi, str
 // add scalar to diagonal
 void blasfeo_ddiare(int kmax, double alpha, struct blasfeo_dmat *sA, int ai, int aj)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int lda = sA->m;
 	double *pA = sA->pA + ai + aj*lda;
 	int ii;
@@ -183,9 +199,12 @@ void blasfeo_drowex(int kmax, double alpha, struct blasfeo_dmat *sA, int ai, int
 
 
 
-// insert a vector  into a row
+// insert a vector into a row
 void blasfeo_drowin(int kmax, double alpha, struct blasfeo_dvec *sx, int xi, struct blasfeo_dmat *sA, int ai, int aj)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int lda = sA->m;
 	double *pA = sA->pA + ai + aj*lda;
 	double *x = sx->pa + xi;
@@ -200,6 +219,9 @@ void blasfeo_drowin(int kmax, double alpha, struct blasfeo_dvec *sx, int xi, str
 // add a vector to a row
 void blasfeo_drowad(int kmax, double alpha, struct blasfeo_dvec *sx, int xi, struct blasfeo_dmat *sA, int ai, int aj)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int lda = sA->m;
 	double *pA = sA->pA + ai + aj*lda;
 	double *x = sx->pa + xi;
@@ -211,9 +233,13 @@ void blasfeo_drowad(int kmax, double alpha, struct blasfeo_dvec *sx, int xi, str
 
 
 
-// swap two rows of a matrix struct
+// swap two rows of two matrix structs
 void blasfeo_drowsw(int kmax, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dmat *sC, int ci, int cj)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+	sC->use_dA = 0;
+
 	int lda = sA->m;
 	double *pA = sA->pA + ai + aj*lda;
 	int ldc = sC->m;
@@ -234,6 +260,9 @@ void blasfeo_drowsw(int kmax, struct blasfeo_dmat *sA, int ai, int aj, struct bl
 // permute the rows of a matrix struct
 void blasfeo_drowpe(int kmax, int *ipiv, struct blasfeo_dmat *sA)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int ii;
 	for(ii=0; ii<kmax; ii++)
 		{
@@ -248,6 +277,9 @@ void blasfeo_drowpe(int kmax, int *ipiv, struct blasfeo_dmat *sA)
 // inverse permute the rows of a matrix struct
 void blasfeo_drowpei(int kmax, int *ipiv, struct blasfeo_dmat *sA)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int ii;
 	for(ii=kmax-1; ii>=0; ii--)
 		{
@@ -273,9 +305,12 @@ void blasfeo_dcolex(int kmax, struct blasfeo_dmat *sA, int ai, int aj, struct bl
 
 
 
-// insert a vector  into a rcol
+// insert a vector into a calumn
 void blasfeo_dcolin(int kmax, struct blasfeo_dvec *sx, int xi, struct blasfeo_dmat *sA, int ai, int aj)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int lda = sA->m;
 	double *pA = sA->pA + ai + aj*lda;
 	double *x = sx->pa + xi;
@@ -287,9 +322,13 @@ void blasfeo_dcolin(int kmax, struct blasfeo_dvec *sx, int xi, struct blasfeo_dm
 
 
 
-// swap two cols of a matrix struct
+// swap two cols of two matrix structs
 void blasfeo_dcolsw(int kmax, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dmat *sC, int ci, int cj)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+	sC->use_dA = 0;
+
 	int lda = sA->m;
 	double *pA = sA->pA + ai + aj*lda;
 	int ldc = sC->m;
@@ -310,6 +349,9 @@ void blasfeo_dcolsw(int kmax, struct blasfeo_dmat *sA, int ai, int aj, struct bl
 // permute the cols of a matrix struct
 void blasfeo_dcolpe(int kmax, int *ipiv, struct blasfeo_dmat *sA)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int ii;
 	for(ii=0; ii<kmax; ii++)
 		{
@@ -324,11 +366,148 @@ void blasfeo_dcolpe(int kmax, int *ipiv, struct blasfeo_dmat *sA)
 // inverse permute the cols of a matrix struct
 void blasfeo_dcolpei(int kmax, int *ipiv, struct blasfeo_dmat *sA)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int ii;
 	for(ii=kmax-1; ii>=0; ii--)
 		{
 		if(ipiv[ii]!=ii)
 			blasfeo_dcolsw(sA->m, sA, 0, ii, sA, 0, ipiv[ii]);
+		}
+	return;
+	}
+
+
+
+// copy a lower triangular strmat into a lower triangular strmat
+void blasfeo_dtrcp_l(int m, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dmat *sC, int ci, int cj)
+	{
+	// invalidate stored inverse diagonal
+	sC->use_dA = 0;
+
+	int lda = sA->m;
+	double *pA = sA->pA + ai + aj*lda;
+	int ldc = sC->m;
+	double *pC = sC->pA + ci + cj*ldc;
+	int ii, jj;
+	for(jj=0; jj<m; jj++)
+		{
+		ii = jj;
+		for(; ii<m; ii++)
+			{
+			pC[ii+0+jj*ldc] = pA[ii+0+jj*lda];
+			}
+		}
+	return;
+	}
+
+
+
+// scale and add a generic strmat into a generic strmat
+void blasfeo_dgead(int m, int n, double alpha, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dmat *sC, int ci, int cj)
+	{
+	// invalidate stored inverse diagonal
+	sC->use_dA = 0;
+
+	int lda = sA->m;
+	double *pA = sA->pA + ai + aj*lda;
+	int ldc = sC->m;
+	double *pC = sC->pA + ci + cj*ldc;
+	int ii, jj;
+	for(jj=0; jj<n; jj++)
+		{
+		ii = 0;
+		for(; ii<m-3; ii+=4)
+			{
+			pC[ii+0+jj*ldc] += alpha*pA[ii+0+jj*lda];
+			pC[ii+1+jj*ldc] += alpha*pA[ii+1+jj*lda];
+			pC[ii+2+jj*ldc] += alpha*pA[ii+2+jj*lda];
+			pC[ii+3+jj*ldc] += alpha*pA[ii+3+jj*lda];
+			}
+		for(; ii<m; ii++)
+			{
+			pC[ii+0+jj*ldc] += alpha*pA[ii+0+jj*lda];
+			}
+		}
+	return;
+	}
+
+
+
+// copy and transpose a generic strmat into a generic strmat
+void blasfeo_dgetr(int m, int n, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dmat *sC, int ci, int cj)
+	{
+	// invalidate stored inverse diagonal
+	sC->use_dA = 0;
+
+	int lda = sA->m;
+	double *pA = sA->pA + ai + aj*lda;
+	int ldc = sC->m;
+	double *pC = sC->pA + ci + cj*ldc;
+	int ii, jj;
+	for(jj=0; jj<n; jj++)
+		{
+		ii = 0;
+		for(; ii<m-3; ii+=4)
+			{
+			pC[jj+(ii+0)*ldc] = pA[ii+0+jj*lda];
+			pC[jj+(ii+1)*ldc] = pA[ii+1+jj*lda];
+			pC[jj+(ii+2)*ldc] = pA[ii+2+jj*lda];
+			pC[jj+(ii+3)*ldc] = pA[ii+3+jj*lda];
+			}
+		for(; ii<m; ii++)
+			{
+			pC[jj+(ii+0)*ldc] = pA[ii+0+jj*lda];
+			}
+		}
+	return;
+	}
+
+
+
+// copy and transpose a lower triangular strmat into an upper triangular strmat
+void blasfeo_dtrtr_l(int m, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dmat *sC, int ci, int cj)
+	{
+	// invalidate stored inverse diagonal
+	sC->use_dA = 0;
+
+	int lda = sA->m;
+	double *pA = sA->pA + ai + aj*lda;
+	int ldc = sC->m;
+	double *pC = sC->pA + ci + cj*ldc;
+	int ii, jj;
+	for(jj=0; jj<m; jj++)
+		{
+		ii = jj;
+		for(; ii<m; ii++)
+			{
+			pC[jj+(ii+0)*ldc] = pA[ii+0+jj*lda];
+			}
+		}
+	return;
+	}
+
+
+
+// copy and transpose an upper triangular strmat into a lower triangular strmat
+void blasfeo_dtrtr_u(int m, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dmat *sC, int ci, int cj)
+	{
+	// invalidate stored inverse diagonal
+	sC->use_dA = 0;
+
+	int lda = sA->m;
+	double *pA = sA->pA + ai + aj*lda;
+	int ldc = sC->m;
+	double *pC = sC->pA + ci + cj*ldc;
+	int ii, jj;
+	for(jj=0; jj<m; jj++)
+		{
+		ii = 0;
+		for(; ii<=jj; ii++)
+			{
+			pC[jj+(ii+0)*ldc] = pA[ii+0+jj*lda];
+			}
 		}
 	return;
 	}
@@ -357,6 +536,8 @@ void blasfeo_dveccp(int m, struct blasfeo_dvec *sa, int ai, struct blasfeo_dvec 
 		}
 	return;
 	}
+
+
 
 // scale a strvec
 void blasfeo_dvecsc(int m, double alpha, struct blasfeo_dvec *sa, int ai)
@@ -403,55 +584,6 @@ void blasfeo_dveccpsc(int m, double alpha, struct blasfeo_dvec *sa, int ai, stru
 
 
 
-// copy a lower triangular strmat into a lower triangular strmat
-void blasfeo_dtrcp_l(int m, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dmat *sC, int ci, int cj)
-	{
-	int lda = sA->m;
-	double *pA = sA->pA + ai + aj*lda;
-	int ldc = sC->m;
-	double *pC = sC->pA + ci + cj*ldc;
-	int ii, jj;
-	for(jj=0; jj<m; jj++)
-		{
-		ii = jj;
-		for(; ii<m; ii++)
-			{
-			pC[ii+0+jj*ldc] = pA[ii+0+jj*lda];
-			}
-		}
-	return;
-	}
-
-
-
-// scale and add a generic strmat into a generic strmat
-void blasfeo_dgead(int m, int n, double alpha, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dmat *sC, int ci, int cj)
-	{
-	int lda = sA->m;
-	double *pA = sA->pA + ai + aj*lda;
-	int ldc = sC->m;
-	double *pC = sC->pA + ci + cj*ldc;
-	int ii, jj;
-	for(jj=0; jj<n; jj++)
-		{
-		ii = 0;
-		for(; ii<m-3; ii+=4)
-			{
-			pC[ii+0+jj*ldc] += alpha*pA[ii+0+jj*lda];
-			pC[ii+1+jj*ldc] += alpha*pA[ii+1+jj*lda];
-			pC[ii+2+jj*ldc] += alpha*pA[ii+2+jj*lda];
-			pC[ii+3+jj*ldc] += alpha*pA[ii+3+jj*lda];
-			}
-		for(; ii<m; ii++)
-			{
-			pC[ii+0+jj*ldc] += alpha*pA[ii+0+jj*lda];
-			}
-		}
-	return;
-	}
-
-
-
 // scales and adds a strvec into a strvec
 void blasfeo_dvecad(int m, double alpha, struct blasfeo_dvec *sa, int ai, struct blasfeo_dvec *sc, int ci)
 	{
@@ -475,79 +607,12 @@ void blasfeo_dvecad(int m, double alpha, struct blasfeo_dvec *sa, int ai, struct
 
 
 
-// copy and transpose a generic strmat into a generic strmat
-void blasfeo_dgetr(int m, int n, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dmat *sC, int ci, int cj)
-	{
-	int lda = sA->m;
-	double *pA = sA->pA + ai + aj*lda;
-	int ldc = sC->m;
-	double *pC = sC->pA + ci + cj*ldc;
-	int ii, jj;
-	for(jj=0; jj<n; jj++)
-		{
-		ii = 0;
-		for(; ii<m-3; ii+=4)
-			{
-			pC[jj+(ii+0)*ldc] = pA[ii+0+jj*lda];
-			pC[jj+(ii+1)*ldc] = pA[ii+1+jj*lda];
-			pC[jj+(ii+2)*ldc] = pA[ii+2+jj*lda];
-			pC[jj+(ii+3)*ldc] = pA[ii+3+jj*lda];
-			}
-		for(; ii<m; ii++)
-			{
-			pC[jj+(ii+0)*ldc] = pA[ii+0+jj*lda];
-			}
-		}
-	return;
-	}
-
-
-
-// copy and transpose a lower triangular strmat into an upper triangular strmat
-void blasfeo_dtrtr_l(int m, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dmat *sC, int ci, int cj)
-	{
-	int lda = sA->m;
-	double *pA = sA->pA + ai + aj*lda;
-	int ldc = sC->m;
-	double *pC = sC->pA + ci + cj*ldc;
-	int ii, jj;
-	for(jj=0; jj<m; jj++)
-		{
-		ii = jj;
-		for(; ii<m; ii++)
-			{
-			pC[jj+(ii+0)*ldc] = pA[ii+0+jj*lda];
-			}
-		}
-	return;
-	}
-
-
-
-// copy and transpose an upper triangular strmat into a lower triangular strmat
-void blasfeo_dtrtr_u(int m, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dmat *sC, int ci, int cj)
-	{
-	int lda = sA->m;
-	double *pA = sA->pA + ai + aj*lda;
-	int ldc = sC->m;
-	double *pC = sC->pA + ci + cj*ldc;
-	int ii, jj;
-	for(jj=0; jj<m; jj++)
-		{
-		ii = 0;
-		for(; ii<=jj; ii++)
-			{
-			pC[jj+(ii+0)*ldc] = pA[ii+0+jj*lda];
-			}
-		}
-	return;
-	}
-
-
-
 // insert a strvec to the diagonal of a strmat, sparse formulation
 void blasfeo_ddiain_sp(int kmax, double alpha, struct blasfeo_dvec *sx, int xi, int *idx, struct blasfeo_dmat *sD, int di, int dj)
 	{
+	// invalidate stored inverse diagonal
+	sD->use_dA = 0;
+
 	double *x = sx->pa + xi;
 	int ldd = sD->m;
 	double *pD = sD->pA + di + dj*ldd;
@@ -576,7 +641,7 @@ void blasfeo_ddiaex(int kmax, double alpha, struct blasfeo_dmat *sA, int ai, int
 
 
 
-// extract the diagonal of a strmat from a strvec , sparse formulation
+// extract the diagonal of a strmat from a strvec, sparse formulation
 void blasfeo_ddiaex_sp(int kmax, double alpha, int *idx, struct blasfeo_dmat *sD, int di, int dj, struct blasfeo_dvec *sx, int xi)
 	{
 	double *x = sx->pa + xi;
@@ -596,6 +661,9 @@ void blasfeo_ddiaex_sp(int kmax, double alpha, int *idx, struct blasfeo_dmat *sD
 // add a vector to diagonal
 void blasfeo_ddiaad(int kmax, double alpha, struct blasfeo_dvec *sx, int xi, struct blasfeo_dmat *sA, int ai, int aj)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int lda = sA->m;
 	double *pA = sA->pA + ai + aj*lda;
 	double *x = sx->pa + xi;
@@ -607,9 +675,12 @@ void blasfeo_ddiaad(int kmax, double alpha, struct blasfeo_dvec *sx, int xi, str
 
 
 
-// add scaled strvec to another strvec and insert to diagonal of strmat, sparse formulation
+// add scaled strvec to another strvec and add to diagonal of strmat, sparse formulation
 void blasfeo_ddiaad_sp(int kmax, double alpha, struct blasfeo_dvec *sx, int xi, int *idx, struct blasfeo_dmat *sD, int di, int dj)
 	{
+	// invalidate stored inverse diagonal
+	sD->use_dA = 0;
+
 	double *x = sx->pa + xi;
 	int ldd = sD->m;
 	double *pD = sD->pA + di + dj*ldd;
@@ -645,6 +716,9 @@ void blasfeo_ddiaadin_sp(int kmax, double alpha, struct blasfeo_dvec *sx, int xi
 // add scaled strvec to row of strmat, sparse formulation
 void blasfeo_drowad_sp(int kmax, double alpha, struct blasfeo_dvec *sx, int xi, int *idx, struct blasfeo_dmat *sD, int di, int dj)
 	{
+	// invalidate stored inverse diagonal
+	sD->use_dA = 0;
+
 	double *x = sx->pa + xi;
 	int ldd = sD->m;
 	double *pD = sD->pA + di + dj*ldd;
@@ -658,8 +732,7 @@ void blasfeo_drowad_sp(int kmax, double alpha, struct blasfeo_dvec *sx, int xi, 
 	}
 
 
-
-
+// add scaled strvec to strvec, sparse formulation
 void blasfeo_dvecad_sp(int m, double alpha, struct blasfeo_dvec *sx, int xi, int *idx, struct blasfeo_dvec *sz, int zi)
 	{
 	double *x = sx->pa + xi;
@@ -671,7 +744,7 @@ void blasfeo_dvecad_sp(int m, double alpha, struct blasfeo_dvec *sx, int xi, int
 	}
 
 
-
+// insert scaled strvec to strvec, sparse formulation
 void blasfeo_dvecin_sp(int m, double alpha, struct blasfeo_dvec *sx, int xi, int *idx, struct blasfeo_dvec *sz, int zi)
 	{
 	double *x = sx->pa + xi;
@@ -684,6 +757,7 @@ void blasfeo_dvecin_sp(int m, double alpha, struct blasfeo_dvec *sx, int xi, int
 
 
 
+// extract scaled strvec to strvec, sparse formulation
 void blasfeo_dvecex_sp(int m, double alpha, int *idx, struct blasfeo_dvec *sx, int xi, struct blasfeo_dvec *sz, int zi)
 	{
 	double *x = sx->pa + xi;
@@ -695,7 +769,7 @@ void blasfeo_dvecex_sp(int m, double alpha, int *idx, struct blasfeo_dvec *sx, i
 	}
 
 
-// clip without mask return
+// clip strvec between two strvec
 void blasfeo_dveccl(int m, struct blasfeo_dvec *sxm, int xim, struct blasfeo_dvec *sx, int xi, struct blasfeo_dvec *sxp, int xip, struct blasfeo_dvec *sz, int zi)
 	{
 	double *xm = sxm->pa + xim;
@@ -723,7 +797,7 @@ void blasfeo_dveccl(int m, struct blasfeo_dvec *sxm, int xim, struct blasfeo_dve
 
 
 
-// clip with mask return
+// clip strvec between two strvec, with mask
 void blasfeo_dveccl_mask(int m, struct blasfeo_dvec *sxm, int xim, struct blasfeo_dvec *sx, int xi, struct blasfeo_dvec *sxp, int xip, struct blasfeo_dvec *sz, int zi, struct blasfeo_dvec *sm, int mi)
 	{
 	double *xm = sxm->pa + xim;
@@ -754,7 +828,7 @@ void blasfeo_dveccl_mask(int m, struct blasfeo_dvec *sxm, int xim, struct blasfe
 	}
 
 
-// zero out components using mask
+// zero out strvec, with mask
 void blasfeo_dvecze(int m, struct blasfeo_dvec *sm, int mi, struct blasfeo_dvec *sv, int vi, struct blasfeo_dvec *se, int ei)
 	{
 	double *mask = sm->pa + mi;
@@ -776,7 +850,7 @@ void blasfeo_dvecze(int m, struct blasfeo_dvec *sm, int mi, struct blasfeo_dvec 
 	}
 
 
-
+// compute inf norm of strvec
 void blasfeo_dvecnrm_inf(int m, struct blasfeo_dvec *sx, int xi, double *ptr_norm)
 	{
 	int ii;
@@ -827,6 +901,8 @@ void blasfeo_dvecpei(int kmax, int *ipiv, struct blasfeo_dvec *sx, int xi)
 		}
 	return;
 	}
+
+
 
 // 1 norm, lower triangular, non-unit
 #if 0

--- a/auxiliary/s_aux_lib.c
+++ b/auxiliary/s_aux_lib.c
@@ -69,6 +69,9 @@
 // insert element into strmat
 void blasfeo_sgein1(float a, struct blasfeo_smat *sA, int ai, int aj)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int lda = sA->m;
 	float *pA = sA->pA + ai + aj*lda;
 	pA[0] = a;
@@ -80,6 +83,12 @@ void blasfeo_sgein1(float a, struct blasfeo_smat *sA, int ai, int aj)
 // extract element from strmat
 float blasfeo_sgeex1(struct blasfeo_smat *sA, int ai, int aj)
 	{
+	if (ai==aj)
+		{
+		// invalidate stored inverse diagonal
+		sA->use_dA = 0;
+		}
+
 	int lda = sA->m;
 	float *pA = sA->pA + ai + aj*lda;
 	return pA[0];
@@ -109,6 +118,9 @@ float blasfeo_svecex1(struct blasfeo_svec *sx, int xi)
 // set all elements of a strmat to a value
 void blasfeo_sgese(int m, int n, float alpha, struct blasfeo_smat *sA, int ai, int aj)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int lda = sA->m;
 	float *pA = sA->pA + ai + aj*lda;
 	int ii, jj;
@@ -153,6 +165,9 @@ void blasfeo_sdiaex(int kmax, float alpha, struct blasfeo_smat *sA, int ai, int 
 // insert a vector into diagonal
 void blasfeo_sdiain(int kmax, float alpha, struct blasfeo_svec *sx, int xi, struct blasfeo_smat *sA, int ai, int aj)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int lda = sA->m;
 	float *pA = sA->pA + ai + aj*lda;
 	float *x = sx->pa + xi;
@@ -167,6 +182,9 @@ void blasfeo_sdiain(int kmax, float alpha, struct blasfeo_svec *sx, int xi, stru
 // add scalar to diagonal
 void blasfeo_sdiare(int kmax, float alpha, struct blasfeo_smat *sA, int ai, int aj)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int lda = sA->m;
 	float *pA = sA->pA + ai + aj*lda;
 	int ii;
@@ -191,9 +209,12 @@ void blasfeo_srowex(int kmax, float alpha, struct blasfeo_smat *sA, int ai, int 
 
 
 
-// insert a vector  into a row
+// insert a vector into a row
 void blasfeo_srowin(int kmax, float alpha, struct blasfeo_svec *sx, int xi, struct blasfeo_smat *sA, int ai, int aj)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int lda = sA->m;
 	float *pA = sA->pA + ai + aj*lda;
 	float *x = sx->pa + xi;
@@ -208,6 +229,9 @@ void blasfeo_srowin(int kmax, float alpha, struct blasfeo_svec *sx, int xi, stru
 // add a vector to a row
 void blasfeo_srowad(int kmax, float alpha, struct blasfeo_svec *sx, int xi, struct blasfeo_smat *sA, int ai, int aj)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int lda = sA->m;
 	float *pA = sA->pA + ai + aj*lda;
 	float *x = sx->pa + xi;
@@ -219,9 +243,13 @@ void blasfeo_srowad(int kmax, float alpha, struct blasfeo_svec *sx, int xi, stru
 
 
 
-// swap two rows of a matrix struct
+// swap two rows of two matrix structs
 void blasfeo_srowsw(int kmax, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_smat *sC, int ci, int cj)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+	sC->use_dA = 0;
+
 	int lda = sA->m;
 	float *pA = sA->pA + ai + aj*lda;
 	int ldc = sC->m;
@@ -242,6 +270,9 @@ void blasfeo_srowsw(int kmax, struct blasfeo_smat *sA, int ai, int aj, struct bl
 // permute the rows of a matrix struct
 void blasfeo_srowpe(int kmax, int *ipiv, struct blasfeo_smat *sA)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int ii;
 	for(ii=0; ii<kmax; ii++)
 		{
@@ -253,8 +284,12 @@ void blasfeo_srowpe(int kmax, int *ipiv, struct blasfeo_smat *sA)
 
 
 
+// inverse permute the rows of a matrix struct
 void blasfeo_srowpei(int kmax, int *ipiv, struct blasfeo_smat *sA)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int ii;
 	for(ii=kmax-1; ii>=0; ii--)
 		{
@@ -266,9 +301,12 @@ void blasfeo_srowpei(int kmax, int *ipiv, struct blasfeo_smat *sA)
 
 
 
-// insert a vector  into a rcol
+// insert a vector into a column of a matrix struct
 void blasfeo_scolin(int kmax, struct blasfeo_svec *sx, int xi, struct blasfeo_smat *sA, int ai, int aj)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int lda = sA->m;
 	float *pA = sA->pA + ai + aj*lda;
 	float *x = sx->pa + xi;
@@ -280,9 +318,13 @@ void blasfeo_scolin(int kmax, struct blasfeo_svec *sx, int xi, struct blasfeo_sm
 
 
 
-// swap two cols of a matrix struct
+// swap two cols of two matrix structs
 void blasfeo_scolsw(int kmax, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_smat *sC, int ci, int cj)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+	sC->use_dA = 0;
+
 	int lda = sA->m;
 	float *pA = sA->pA + ai + aj*lda;
 	int ldc = sC->m;
@@ -303,6 +345,9 @@ void blasfeo_scolsw(int kmax, struct blasfeo_smat *sA, int ai, int aj, struct bl
 // permute the cols of a matrix struct
 void blasfeo_scolpe(int kmax, int *ipiv, struct blasfeo_smat *sA)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int ii;
 	for(ii=0; ii<kmax; ii++)
 		{
@@ -317,6 +362,9 @@ void blasfeo_scolpe(int kmax, int *ipiv, struct blasfeo_smat *sA)
 // inverse permute the cols of a matrix struct
 void blasfeo_scolpei(int kmax, int *ipiv, struct blasfeo_smat *sA)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int ii;
 	for(ii=kmax-1; ii>=0; ii--)
 		{
@@ -399,6 +447,9 @@ void blasfeo_sveccpsc(int m, float alpha, struct blasfeo_svec *sa, int ai, struc
 // copy a lower triangular strmat into a lower triangular strmat
 void blasfeo_strcp_l(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_smat *sC, int ci, int cj)
 	{
+	// invalidate stored inverse diagonal
+	sC->use_dA = 0;
+
 	int lda = sA->m;
 	float *pA = sA->pA + ai + aj*lda;
 	int ldc = sC->m;
@@ -420,6 +471,9 @@ void blasfeo_strcp_l(int m, struct blasfeo_smat *sA, int ai, int aj, struct blas
 // scale and add a generic strmat into a generic strmat
 void blasfeo_sgead(int m, int n, float alpha, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_smat *sC, int ci, int cj)
 	{
+	// invalidate stored inverse diagonal
+	sC->use_dA = 0;
+
 	int lda = sA->m;
 	float *pA = sA->pA + ai + aj*lda;
 	int ldc = sC->m;
@@ -471,6 +525,9 @@ void blasfeo_svecad(int m, float alpha, struct blasfeo_svec *sa, int ai, struct 
 // copy and transpose a generic strmat into a generic strmat
 void blasfeo_sgetr(int m, int n, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_smat *sC, int ci, int cj)
 	{
+	// invalidate stored inverse diagonal
+	sC->use_dA = 0;
+
 	int lda = sA->m;
 	float *pA = sA->pA + ai + aj*lda;
 	int ldc = sC->m;
@@ -499,6 +556,9 @@ void blasfeo_sgetr(int m, int n, struct blasfeo_smat *sA, int ai, int aj, struct
 // copy and transpose a lower triangular strmat into an upper triangular strmat
 void blasfeo_strtr_l(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_smat *sC, int ci, int cj)
 	{
+	// invalidate stored inverse diagonal
+	sC->use_dA = 0;
+
 	int lda = sA->m;
 	float *pA = sA->pA + ai + aj*lda;
 	int ldc = sC->m;
@@ -520,6 +580,9 @@ void blasfeo_strtr_l(int m, struct blasfeo_smat *sA, int ai, int aj, struct blas
 // copy and transpose an upper triangular strmat into a lower triangular strmat
 void blasfeo_strtr_u(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_smat *sC, int ci, int cj)
 	{
+	// invalidate stored inverse diagonal
+	sC->use_dA = 0;
+
 	int lda = sA->m;
 	float *pA = sA->pA + ai + aj*lda;
 	int ldc = sC->m;
@@ -541,6 +604,9 @@ void blasfeo_strtr_u(int m, struct blasfeo_smat *sA, int ai, int aj, struct blas
 // insert a strvec to the diagonal of a strmat, sparse formulation
 void blasfeo_sdiain_sp(int kmax, float alpha, struct blasfeo_svec *sx, int xi, int *idx, struct blasfeo_smat *sD, int di, int dj)
 	{
+	// invalidate stored inverse diagonal
+	sD->use_dA = 0;
+
 	float *x = sx->pa + xi;
 	int ldd = sD->m;
 	float *pD = sD->pA + di + dj*ldd;
@@ -572,9 +638,12 @@ void blasfeo_sdiaex_sp(int kmax, float alpha, int *idx, struct blasfeo_smat *sD,
 
 
 
-// add a vector to diagonal
+// add a vector to diagonal of a matrix struct
 void blasfeo_sdiaad(int kmax, float alpha, struct blasfeo_svec *sx, int xi, struct blasfeo_smat *sA, int ai, int aj)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int lda = sA->m;
 	float *pA = sA->pA + ai + aj*lda;
 	float *x = sx->pa + xi;
@@ -589,6 +658,9 @@ void blasfeo_sdiaad(int kmax, float alpha, struct blasfeo_svec *sx, int xi, stru
 // add scaled strvec to another strvec and insert to diagonal of strmat, sparse formulation
 void blasfeo_sdiaad_sp(int kmax, float alpha, struct blasfeo_svec *sx, int xi, int *idx, struct blasfeo_smat *sD, int di, int dj)
 	{
+	// invalidate stored inverse diagonal
+	sD->use_dA = 0;
+
 	float *x = sx->pa + xi;
 	int ldd = sD->m;
 	float *pD = sD->pA + di + dj*ldd;
@@ -606,6 +678,9 @@ void blasfeo_sdiaad_sp(int kmax, float alpha, struct blasfeo_svec *sx, int xi, i
 // add scaled strvec to another strvec and insert to diagonal of strmat, sparse formulation
 void blasfeo_sdiaadin_sp(int kmax, float alpha, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sy, int yi, int *idx, struct blasfeo_smat *sD, int di, int dj)
 	{
+	// invalidate stored inverse diagonal
+	sD->use_dA = 0;
+
 	float *x = sx->pa + xi;
 	float *y = sy->pa + yi;
 	int ldd = sD->m;
@@ -624,6 +699,9 @@ void blasfeo_sdiaadin_sp(int kmax, float alpha, struct blasfeo_svec *sx, int xi,
 // add scaled strvec to row of strmat, sparse formulation
 void blasfeo_srowad_sp(int kmax, float alpha, struct blasfeo_svec *sx, int xi, int *idx, struct blasfeo_smat *sD, int di, int dj)
 	{
+	// invalidate stored inverse diagonal
+	sD->use_dA = 0;
+
 	float *x = sx->pa + xi;
 	int ldd = sD->m;
 	float *pD = sD->pA + di + dj*ldd;
@@ -638,7 +716,7 @@ void blasfeo_srowad_sp(int kmax, float alpha, struct blasfeo_svec *sx, int xi, i
 
 
 
-
+// add scaled strvec to another strvec, sparse formulation
 void blasfeo_svecad_sp(int m, float alpha, struct blasfeo_svec *sx, int xi, int *idx, struct blasfeo_svec *sz, int zi)
 	{
 	float *x = sx->pa + xi;
@@ -651,6 +729,7 @@ void blasfeo_svecad_sp(int m, float alpha, struct blasfeo_svec *sx, int xi, int 
 
 
 
+// insert  scaled strvec to another strvec, sparse formulation
 void blasfeo_svecin_sp(int m, float alpha, struct blasfeo_svec *sx, int xi, int *idx, struct blasfeo_svec *sz, int zi)
 	{
 	float *x = sx->pa + xi;
@@ -662,7 +741,7 @@ void blasfeo_svecin_sp(int m, float alpha, struct blasfeo_svec *sx, int xi, int 
 	}
 
 
-
+// extract scaled strvec to strvec, sparse formulation
 void blasfeo_svecex_sp(int m, float alpha, int *idx, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
 	{
 	float *x = sx->pa + xi;
@@ -674,7 +753,7 @@ void blasfeo_svecex_sp(int m, float alpha, int *idx, struct blasfeo_svec *sx, in
 	}
 
 
-// clip without mask return
+// clip strvec between two strvec
 void blasfeo_sveccl(int m, struct blasfeo_svec *sxm, int xim, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sxp, int xip, struct blasfeo_svec *sz, int zi)
 	{
 	float *xm = sxm->pa + xim;
@@ -702,7 +781,7 @@ void blasfeo_sveccl(int m, struct blasfeo_svec *sxm, int xim, struct blasfeo_sve
 
 
 
-// clip with mask return
+// clip strvec between two strvec, with mask
 void blasfeo_sveccl_mask(int m, struct blasfeo_svec *sxm, int xim, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sxp, int xip, struct blasfeo_svec *sz, int zi, struct blasfeo_svec *sm, int mi)
 	{
 	float *xm = sxm->pa + xim;
@@ -733,7 +812,7 @@ void blasfeo_sveccl_mask(int m, struct blasfeo_svec *sxm, int xim, struct blasfe
 	}
 
 
-// zero out components using mask
+// zero out strvec, with mask
 void blasfeo_svecze(int m, struct blasfeo_svec *sm, int mi, struct blasfeo_svec *sv, int vi, struct blasfeo_svec *se, int ei)
 	{
 	float *mask = sm->pa + mi;
@@ -756,6 +835,7 @@ void blasfeo_svecze(int m, struct blasfeo_svec *sm, int mi, struct blasfeo_svec 
 
 
 
+// compute inf norm of strvec
 void blasfeo_svecnrm_inf(int m, struct blasfeo_svec *sx, int xi, float *ptr_norm)
 	{
 	int ii;

--- a/auxiliary/s_aux_lib4.c
+++ b/auxiliary/s_aux_lib4.c
@@ -1243,6 +1243,10 @@ int blasfeo_memsize_diag_smat(int m, int n)
 // create a matrix structure for a matrix of size m*n by using memory passed by a pointer
 void blasfeo_create_smat(int m, int n, struct blasfeo_smat *sA, void *memory)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	const int bs = 4;
 	int nc = S_NC;
 	int al = bs*nc;
@@ -1258,7 +1262,6 @@ void blasfeo_create_smat(int m, int n, struct blasfeo_smat *sA, void *memory)
 	int tmp = m<n ? (m+al-1)/al*al : (n+al-1)/al*al; // al(min(m,n)) // XXX max ???
 	sA->dA = ptr;
 	ptr += tmp;
-	sA->use_dA = 0;
 	sA->memsize = (pm*cn+tmp)*sizeof(float);
 	return;
 	}
@@ -1299,6 +1302,10 @@ void blasfeo_create_svec(int m, struct blasfeo_svec *sa, void *memory)
 // convert a matrix into a matrix structure
 void blasfeo_pack_smat(int m, int n, float *A, int lda, struct blasfeo_smat *sA, int ai, int aj)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	const int bs = 4;
 	int sda = sA->cn;
 	float *pA = sA->pA + aj*bs + ai/bs*bs*sda + ai%bs;
@@ -1411,6 +1418,10 @@ void blasfeo_pack_smat(int m, int n, float *A, int lda, struct blasfeo_smat *sA,
 // convert and transpose a matrix into a matrix structure
 void blasfeo_pack_tran_smat(int m, int n, float *A, int lda, struct blasfeo_smat *sA, int ai, int aj)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	const int bs = 4;
 	int sda = sA->cn;
 	float *pA = sA->pA + aj*bs + ai/bs*bs*sda + ai%bs;
@@ -1723,6 +1734,10 @@ void blasfeo_unpack_svec(int m, struct blasfeo_svec *sa, int ai, float *a)
 // cast a matrix into a matrix structure
 void s_cast_mat2strmat(float *A, struct blasfeo_smat *sA)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	sA->pA = A;
 	return;
 	}
@@ -1732,6 +1747,10 @@ void s_cast_mat2strmat(float *A, struct blasfeo_smat *sA)
 // cast a matrix into the diagonal of a matrix structure
 void s_cast_diag_mat2strmat(float *dA, struct blasfeo_smat *sA)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	sA->dA = dA;
 	return;
 	}
@@ -1750,6 +1769,13 @@ void s_cast_vec2vecmat(float *a, struct blasfeo_svec *sa)
 // insert element into strmat
 void blasfeo_sgein1(float a, struct blasfeo_smat *sA, int ai, int aj)
 	{
+
+	if (ai == aj)
+		{
+		// invalidate stored inverse diagonal
+		sA->use_dA = 0;
+		}
+
 	const int bs = 4;
 	int sda = sA->cn;
 	float *pA = sA->pA + ai/bs*bs*sda + ai%bs + aj*bs;
@@ -1794,6 +1820,10 @@ float blasfeo_svecex1(struct blasfeo_svec *sx, int xi)
 // set all elements of a strmat to a value
 void blasfeo_sgese(int m, int n, float alpha, struct blasfeo_smat *sA, int ai, int aj)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	const int bs = 4;
 	int sda = sA->cn;
 	float *pA = sA->pA + ai%bs + ai/bs*bs*sda + aj*bs;
@@ -1864,6 +1894,10 @@ void blasfeo_sdiaex(int kmax, float alpha, struct blasfeo_smat *sA, int ai, int 
 // insert a vector into diagonal
 void blasfeo_sdiain(int kmax, float alpha, struct blasfeo_svec *sx, int xi, struct blasfeo_smat *sA, int ai, int aj)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	const int bs = 4;
 	int sda = sA->cn;
 	float *pA = sA->pA + ai/bs*bs*sda + ai%bs + aj*bs;
@@ -1904,6 +1938,10 @@ void blasfeo_sdiain(int kmax, float alpha, struct blasfeo_svec *sx, int xi, stru
 // add scalar to diagonal
 void blasfeo_sdiare(int kmax, float alpha, struct blasfeo_smat *sA, int ai, int aj)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	const int bs = 4;
 	int sda = sA->cn;
 	float *pA = sA->pA + ai/bs*bs*sda + ai%bs + aj*bs;
@@ -1939,9 +1977,14 @@ void blasfeo_sdiare(int kmax, float alpha, struct blasfeo_smat *sA, int ai, int 
 
 
 
-// swap two rows of a matrix struct
+// swap two rows of two matrix structs
 void blasfeo_srowsw(int kmax, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_smat *sC, int ci, int cj)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+	sC->use_dA = 0;
+
 	const int bs = 4;
 	int sda = sA->cn;
 	float *pA = sA->pA + ai/bs*bs*sda + ai%bs + aj*bs;
@@ -1956,6 +1999,10 @@ void blasfeo_srowsw(int kmax, struct blasfeo_smat *sA, int ai, int aj, struct bl
 // permute the rows of a matrix struct
 void blasfeo_srowpe(int kmax, int *ipiv, struct blasfeo_smat *sA)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int ii;
 	for(ii=0; ii<kmax; ii++)
 		{
@@ -1969,6 +2016,10 @@ void blasfeo_srowpe(int kmax, int *ipiv, struct blasfeo_smat *sA)
 // inverse permute the rows of a matrix struct
 void blasfeo_srowpei(int kmax, int *ipiv, struct blasfeo_smat *sA)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int ii;
 	for(ii=kmax-1; ii>=0; ii--)
 		{
@@ -1995,6 +2046,10 @@ void blasfeo_srowex(int kmax, float alpha, struct blasfeo_smat *sA, int ai, int 
 // insert a vector into a row
 void blasfeo_srowin(int kmax, float alpha, struct blasfeo_svec *sx, int xi, struct blasfeo_smat *sA, int ai, int aj)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	const int bs = 4;
 	int sda = sA->cn;
 	float *pA = sA->pA + ai/bs*bs*sda + ai%bs + aj*bs;
@@ -2008,6 +2063,10 @@ void blasfeo_srowin(int kmax, float alpha, struct blasfeo_svec *sx, int xi, stru
 // add a vector to a row
 void blasfeo_srowad(int kmax, float alpha, struct blasfeo_svec *sx, int xi, struct blasfeo_smat *sA, int ai, int aj)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	const int bs = 4;
 	int sda = sA->cn;
 	float *pA = sA->pA + ai/bs*bs*sda + ai%bs + aj*bs;
@@ -2018,9 +2077,14 @@ void blasfeo_srowad(int kmax, float alpha, struct blasfeo_svec *sx, int xi, stru
 
 
 
-// swap two cols of a matrix struct
+// swap two cols of two matrix structs
 void blasfeo_scolsw(int kmax, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_smat *sC, int ci, int cj)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+	sC->use_dA = 0;
+
 	const int bs = 4;
 	int sda = sA->cn;
 	float *pA = sA->pA + ai/bs*bs*sda + ai%bs + aj*bs;
@@ -2035,6 +2099,10 @@ void blasfeo_scolsw(int kmax, struct blasfeo_smat *sA, int ai, int aj, struct bl
 // permute the cols of a matrix struct
 void blasfeo_scolpe(int kmax, int *ipiv, struct blasfeo_smat *sA)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int ii;
 	for(ii=0; ii<kmax; ii++)
 		{
@@ -2049,6 +2117,10 @@ void blasfeo_scolpe(int kmax, int *ipiv, struct blasfeo_smat *sA)
 // inverse permute the cols of a matrix struct
 void blasfeo_scolpei(int kmax, int *ipiv, struct blasfeo_smat *sA)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int ii;
 	for(ii=kmax-1; ii>=0; ii--)
 		{
@@ -2069,6 +2141,9 @@ void blasfeo_sgesc(int m, int n, float alpha, struct blasfeo_smat *sA, int ai, i
 
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
 
 #if defined(DIM_CHECK)
 	// non-negative size
@@ -2158,6 +2233,9 @@ void blasfeo_sgecpsc(int m, int n, float alpha, struct blasfeo_smat *sA, int ai,
 
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal
+	sB->use_dA = 0;
 
 #if defined(DIM_CHECK)
 	// non-negative size
@@ -2452,6 +2530,9 @@ void blasfeo_sgecp(int m, int n, struct blasfeo_smat *sA, int ai, int aj, struct
 
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal
+	sB->use_dA = 0;
 
 #if defined(DIM_CHECK)
 	// non-negative size
@@ -2808,6 +2889,9 @@ void blasfeo_strcp_l(int m, struct blasfeo_smat *sA, int ai, int aj, struct blas
 	if(m<=0)
 		return;
 
+	// invalidate stored inverse diagonal
+	sB->use_dA = 0;
+
 	const int bs = 4;
 
 	int sda = sA->cn;
@@ -3076,6 +3160,10 @@ void blasfeo_sgead(int m, int n, float alpha, struct blasfeo_smat *sA, int ai, i
 
 	if(m<=0 || n<=0)
 		return;
+
+	// invalidate stored inverse diagonal
+	sB->use_dA = 0;
+
 	const int bs = 4;
 
 	int sda = sA->cn;
@@ -3341,6 +3429,12 @@ void blasfeo_sgead(int m, int n, float alpha, struct blasfeo_smat *sA, int ai, i
 // copy and transpose a generic strmat into a generic strmat
 void blasfeo_sgetr(int m, int n, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_smat *sC, int ci, int cj)
 	{
+	if(m<=0 || n<=0)
+		return;
+
+	// invalidate stored inverse diagonal
+	sC->use_dA = 0;
+
 	const int bs = 4;
 	int sda = sA->cn;
 	float *pA = sA->pA + ai/bs*bs*sda + ai%bs + aj*bs;
@@ -3355,6 +3449,12 @@ void blasfeo_sgetr(int m, int n, struct blasfeo_smat *sA, int ai, int aj, struct
 // copy and transpose a lower triangular strmat into an upper triangular strmat
 void blasfeo_strtr_l(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_smat *sC, int ci, int cj)
 	{
+	if(m<=0)
+		return;
+
+	// invalidate stored inverse diagonal
+	sC->use_dA = 0;
+
 	const int bs = 4;
 	int sda = sA->cn;
 	float *pA = sA->pA + ai/bs*bs*sda + ai%bs + aj*bs;
@@ -3369,6 +3469,12 @@ void blasfeo_strtr_l(int m, struct blasfeo_smat *sA, int ai, int aj, struct blas
 // copy and transpose an upper triangular strmat into a lower triangular strmat
 void blasfeo_strtr_u(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_smat *sC, int ci, int cj)
 	{
+	if(m<=0)
+		return;
+
+	// invalidate stored inverse diagonal
+	sC->use_dA = 0;
+
 	const int bs = 4;
 	int sda = sA->cn;
 	float *pA = sA->pA + ai/bs*bs*sda + ai%bs + aj*bs;
@@ -3383,6 +3489,12 @@ void blasfeo_strtr_u(int m, struct blasfeo_smat *sA, int ai, int aj, struct blas
 // insert a strvec to diagonal of strmat, sparse formulation
 void blasfeo_sdiain_sp(int kmax, float alpha, struct blasfeo_svec *sx, int xi, int *idx, struct blasfeo_smat *sD, int di, int dj)
 	{
+	if(kmax<=0)
+		return;
+
+	// invalidate stored inverse diagonal
+	sD->use_dA = 0;
+
 	const int bs = 4;
 	float *x = sx->pa + xi;
 	int sdd = sD->cn;
@@ -3419,6 +3531,12 @@ void blasfeo_sdiaex_sp(int kmax, float alpha, int *idx, struct blasfeo_smat *sD,
 // add scaled strvec to diagonal of strmat, sparse formulation
 void blasfeo_sdiaad_sp(int kmax, float alpha, struct blasfeo_svec *sx, int xi, int *idx, struct blasfeo_smat *sD, int di, int dj)
 	{
+	if(kmax<=0)
+		return;
+
+	// invalidate stored inverse diagonal
+	sD->use_dA = 0;
+
 	const int bs = 4;
 	float *x = sx->pa + xi;
 	int sdd = sD->cn;
@@ -3437,6 +3555,12 @@ void blasfeo_sdiaad_sp(int kmax, float alpha, struct blasfeo_svec *sx, int xi, i
 // add scaled strvec to another strvec and insert to diagonal of strmat, sparse formulation
 void blasfeo_sdiaadin_sp(int kmax, float alpha, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sy, int yi, int *idx, struct blasfeo_smat *sD, int di, int dj)
 	{
+	if(kmax<=0)
+		return;
+
+	// invalidate stored inverse diagonal
+	sD->use_dA = 0;
+
 	const int bs = 4;
 	float *x = sx->pa + xi;
 	float *y = sy->pa + yi;
@@ -3456,6 +3580,12 @@ void blasfeo_sdiaadin_sp(int kmax, float alpha, struct blasfeo_svec *sx, int xi,
 // add scaled strvec to row of strmat, sparse formulation
 void blasfeo_srowad_sp(int kmax, float alpha, struct blasfeo_svec *sx, int xi, int *idx, struct blasfeo_smat *sD, int di, int dj)
 	{
+	if(kmax<=0)
+		return;
+
+	// invalidate stored inverse diagonal
+	sD->use_dA = 0;
+
 	const int bs = 4;
 	float *x = sx->pa + xi;
 	int sdd = sD->cn;

--- a/auxiliary/s_aux_lib8.c
+++ b/auxiliary/s_aux_lib8.c
@@ -931,6 +931,10 @@ void blasfeo_create_svec(int m, struct blasfeo_svec *sa, void *memory)
 // convert a matrix into a matrix structure
 void blasfeo_pack_smat(int m, int n, float *A, int lda, struct blasfeo_smat *sA, int ai, int aj)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	const int bs = 8;
 	int sda = sA->cn;
 	float *pA = sA->pA + aj*bs + ai/bs*bs*sda + ai%bs;
@@ -1063,6 +1067,10 @@ void blasfeo_pack_smat(int m, int n, float *A, int lda, struct blasfeo_smat *sA,
 // convert and transpose a matrix into a matrix structure
 void blasfeo_pack_tran_smat(int m, int n, float *A, int lda, struct blasfeo_smat *sA, int ai, int aj)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	const int bs = 8;
 	int sda = sA->cn;
 	float *pA = sA->pA + aj*bs + ai/bs*bs*sda + ai%bs;
@@ -1435,6 +1443,9 @@ void blasfeo_unpack_svec(int m, struct blasfeo_svec *sa, int ai, float *a)
 // cast a matrix into a matrix structure
 void s_cast_mat2strmat(float *A, struct blasfeo_smat *sA)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	sA->pA = A;
 	return;
 	}
@@ -1444,6 +1455,9 @@ void s_cast_mat2strmat(float *A, struct blasfeo_smat *sA)
 // cast a matrix into the diagonal of a matrix structure
 void s_cast_diag_mat2strmat(float *dA, struct blasfeo_smat *sA)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	sA->dA = dA;
 	return;
 	}
@@ -1462,6 +1476,13 @@ void s_cast_vec2vecmat(float *a, struct blasfeo_svec *sa)
 // insert element into strmat
 void blasfeo_sgein1(float a, struct blasfeo_smat *sA, int ai, int aj)
 	{
+
+	if (ai == aj)
+		{
+		// invalidate stored inverse diagonal
+		sA->use_dA = 0;
+		}
+
 	const int bs = 8;
 	int sda = sA->cn;
 	float *pA = sA->pA + ai/bs*bs*sda + ai%bs + aj*bs;
@@ -1506,6 +1527,10 @@ float blasfeo_svecex1(struct blasfeo_svec *sx, int xi)
 // set all elements of a strmat to a value
 void blasfeo_sgese(int m, int n, float alpha, struct blasfeo_smat *sA, int ai, int aj)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	const int bs = 8;
 	int sda = sA->cn;
 	float *pA = sA->pA + ai%bs + ai/bs*bs*sda + aj*bs;
@@ -1580,6 +1605,10 @@ void blasfeo_sdiaex(int kmax, float alpha, struct blasfeo_smat *sA, int ai, int 
 // insert a vector into diagonal
 void blasfeo_sdiain(int kmax, float alpha, struct blasfeo_svec *sx, int xi, struct blasfeo_smat *sA, int ai, int aj)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	const int bs = 8;
 	int sda = sA->cn;
 	float *pA = sA->pA + ai/bs*bs*sda + ai%bs + aj*bs;
@@ -1593,6 +1622,11 @@ void blasfeo_sdiain(int kmax, float alpha, struct blasfeo_svec *sx, int xi, stru
 // swap two rows of a matrix struct
 void blasfeo_srowsw(int kmax, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_smat *sC, int ci, int cj)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+	sC->use_dA = 0;
+
 	const int bs = 8;
 	int sda = sA->cn;
 	float *pA = sA->pA + ai/bs*bs*sda + ai%bs + aj*bs;
@@ -1607,6 +1641,10 @@ void blasfeo_srowsw(int kmax, struct blasfeo_smat *sA, int ai, int aj, struct bl
 // permute the rows of a matrix struct
 void blasfeo_srowpe(int kmax, int *ipiv, struct blasfeo_smat *sA)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int ii;
 	for(ii=0; ii<kmax; ii++)
 		{
@@ -1620,6 +1658,10 @@ void blasfeo_srowpe(int kmax, int *ipiv, struct blasfeo_smat *sA)
 // inverse permute the rows of a matrix struct
 void blasfeo_srowpei(int kmax, int *ipiv, struct blasfeo_smat *sA)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int ii;
 	for(ii=kmax-1; ii>=0; ii--)
 		{
@@ -1646,6 +1688,10 @@ void blasfeo_srowex(int kmax, float alpha, struct blasfeo_smat *sA, int ai, int 
 // insert a vector into a row
 void blasfeo_srowin(int kmax, float alpha, struct blasfeo_svec *sx, int xi, struct blasfeo_smat *sA, int ai, int aj)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	const int bs = 8;
 	int sda = sA->cn;
 	float *pA = sA->pA + ai/bs*bs*sda + ai%bs + aj*bs;
@@ -1659,6 +1705,10 @@ void blasfeo_srowin(int kmax, float alpha, struct blasfeo_svec *sx, int xi, stru
 // add a vector to a row
 void blasfeo_srowad(int kmax, float alpha, struct blasfeo_svec *sx, int xi, struct blasfeo_smat *sA, int ai, int aj)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	const int bs = 8;
 	int sda = sA->cn;
 	float *pA = sA->pA + ai/bs*bs*sda + ai%bs + aj*bs;
@@ -1672,6 +1722,11 @@ void blasfeo_srowad(int kmax, float alpha, struct blasfeo_svec *sx, int xi, stru
 // swap two cols of a matrix struct
 void blasfeo_scolsw(int kmax, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_smat *sC, int ci, int cj)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+	sC->use_dA = 0;
+
 	const int bs = 8;
 	int sda = sA->cn;
 	float *pA = sA->pA + ai/bs*bs*sda + ai%bs + aj*bs;
@@ -1686,6 +1741,10 @@ void blasfeo_scolsw(int kmax, struct blasfeo_smat *sA, int ai, int aj, struct bl
 // permute the cols of a matrix struct
 void blasfeo_scolpe(int kmax, int *ipiv, struct blasfeo_smat *sA)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int ii;
 	for(ii=0; ii<kmax; ii++)
 		{
@@ -1700,6 +1759,10 @@ void blasfeo_scolpe(int kmax, int *ipiv, struct blasfeo_smat *sA)
 // inverse permute the cols of a matrix struct
 void blasfeo_scolpei(int kmax, int *ipiv, struct blasfeo_smat *sA)
 	{
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int ii;
 	for(ii=kmax-1; ii>=0; ii--)
 		{
@@ -1718,6 +1781,9 @@ void blasfeo_sgesc(int m, int n, float alpha, struct blasfeo_smat *sA, int ai, i
 	// early return
 	if(m==0 | n==0)
 		return;
+
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
 
 #if defined(DIM_CHECK)
 	// non-negative size
@@ -1776,6 +1842,9 @@ void blasfeo_sgecp(int m, int n, struct blasfeo_smat *sA, int ai, int aj, struct
 	// early return
 	if(m==0 | n==0)
 		return;
+
+	// invalidate stored inverse diagonal
+	sB->use_dA = 0;
 
 #if defined(DIM_CHECK)
 	// non-negative size
@@ -2035,6 +2104,9 @@ void blasfeo_sgecpsc(int m, int n, float alpha, struct blasfeo_smat *sA, int ai,
 	// early return
 	if(m==0 | n==0)
 		return;
+
+	// invalidate stored inverse diagonal
+	sB->use_dA = 0;
 
 #if defined(DIM_CHECK)
 	// non-negative size
@@ -2357,6 +2429,10 @@ void blasfeo_sveccpsc(int m, float alpha, struct blasfeo_svec *sa, int ai, struc
 // copy a lower triangular strmat into a lower triangular strmat
 void blasfeo_strcp_l(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_smat *sC, int ci, int cj)
 	{
+
+	// invalidate stored inverse diagonal
+	sC->use_dA = 0;
+
 	const int bs = 8;
 	int sda = sA->cn;
 	float *pA = sA->pA + ai/bs*bs*sda + ai%bs + aj*bs;
@@ -2377,6 +2453,9 @@ void blasfeo_sgead(int m, int n, float alpha, struct blasfeo_smat *sA, int ai, i
 	// early return
 	if(m==0 | n==0)
 		return;
+
+	// invalidate stored inverse diagonal
+	sB->use_dA = 0;
 
 #if defined(DIM_CHECK)
 	// non-negative size
@@ -2640,6 +2719,9 @@ void blasfeo_sgetr(int m, int n, struct blasfeo_smat *sA, int ai, int aj, struct
 	if(m==0 | n==0)
 		return;
 
+	// invalidate stored inverse diagonal
+	sB->use_dA = 0;
+
 #if defined(DIM_CHECK)
 	// non-negative size
 	if(m<0) printf("\n****** blasfeo_sgetr : m<0 : %d<0 *****\n", m);
@@ -2846,6 +2928,10 @@ void blasfeo_sgetr(int m, int n, struct blasfeo_smat *sA, int ai, int aj, struct
 // copy and transpose a lower triangular strmat into an upper triangular strmat
 void blasfeo_strtr_l(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_smat *sC, int ci, int cj)
 	{
+
+	// invalidate stored inverse diagonal
+	sC->use_dA = 0;
+
 	const int bs = 8;
 	int sda = sA->cn;
 	float *pA = sA->pA + ai/bs*bs*sda + ai%bs + aj*bs;
@@ -2860,6 +2946,10 @@ void blasfeo_strtr_l(int m, struct blasfeo_smat *sA, int ai, int aj, struct blas
 // copy and transpose an upper triangular strmat into a lower triangular strmat
 void blasfeo_strtr_u(int m, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_smat *sC, int ci, int cj)
 	{
+
+	// invalidate stored inverse diagonal
+	sC->use_dA = 0;
+
 	const int bs = 8;
 	int sda = sA->cn;
 	float *pA = sA->pA + ai/bs*bs*sda + ai%bs + aj*bs;
@@ -2874,6 +2964,10 @@ void blasfeo_strtr_u(int m, struct blasfeo_smat *sA, int ai, int aj, struct blas
 // insert a strvec to diagonal of strmat, sparse formulation
 void blasfeo_sdiain_sp(int kmax, float alpha, struct blasfeo_svec *sx, int xi, int *idx, struct blasfeo_smat *sD, int di, int dj)
 	{
+
+	// invalidate stored inverse diagonal
+	sD->use_dA = 0;
+
 	const int bs = 8;
 	float *x = sx->pa + xi;
 	int sdd = sD->cn;
@@ -2910,6 +3004,10 @@ void blasfeo_sdiaex_sp(int kmax, float alpha, int *idx, struct blasfeo_smat *sD,
 // add scaled strvec to diagonal of strmat, sparse formulation
 void blasfeo_sdiaad_sp(int kmax, float alpha, struct blasfeo_svec *sx, int xi, int *idx, struct blasfeo_smat *sD, int di, int dj)
 	{
+
+	// invalidate stored inverse diagonal
+	sD->use_dA = 0;
+
 	const int bs = 8;
 	float *x = sx->pa + xi;
 	int sdd = sD->cn;
@@ -2928,6 +3026,10 @@ void blasfeo_sdiaad_sp(int kmax, float alpha, struct blasfeo_svec *sx, int xi, i
 // add scaled strvec to another strvec and insert to diagonal of strmat, sparse formulation
 void blasfeo_sdiaadin_sp(int kmax, float alpha, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sy, int yi, int *idx, struct blasfeo_smat *sD, int di, int dj)
 	{
+
+	// invalidate stored inverse diagonal
+	sD->use_dA = 0;
+
 	const int bs = 8;
 	float *x = sx->pa + xi;
 	float *y = sy->pa + yi;
@@ -2947,6 +3049,10 @@ void blasfeo_sdiaadin_sp(int kmax, float alpha, struct blasfeo_svec *sx, int xi,
 // add scaled strvec to row of strmat, sparse formulation
 void blasfeo_srowad_sp(int kmax, float alpha, struct blasfeo_svec *sx, int xi, int *idx, struct blasfeo_smat *sD, int di, int dj)
 	{
+
+	// invalidate stored inverse diagonal
+	sD->use_dA = 0;
+
 	const int bs = 8;
 	float *x = sx->pa + xi;
 	int sdd = sD->cn;
@@ -2957,7 +3063,7 @@ void blasfeo_srowad_sp(int kmax, float alpha, struct blasfeo_svec *sx, int xi, i
 
 
 
-// adds strvec to strvec, sparse formulation
+// add strvec to strvec, sparse formulation
 void blasfeo_svecad_sp(int kmax, float alpha, struct blasfeo_svec *sx, int xi, int *idx, struct blasfeo_svec *sy, int yi)
 	{
 	float *x = sx->pa + xi;
@@ -2968,6 +3074,7 @@ void blasfeo_svecad_sp(int kmax, float alpha, struct blasfeo_svec *sx, int xi, i
 
 
 
+// insert scaled strvec to strvec, sparse formulation
 void blasfeo_svecin_sp(int m, float alpha, struct blasfeo_svec *sx, int xi, int *idx, struct blasfeo_svec *sz, int zi)
 	{
 	float *x = sx->pa + xi;
@@ -2980,6 +3087,7 @@ void blasfeo_svecin_sp(int m, float alpha, struct blasfeo_svec *sx, int xi, int 
 
 
 
+// extract scaled strvec to strvec, sparse formulation
 void blasfeo_svecex_sp(int m, float alpha, int *idx, struct blasfeo_svec *sx, int xi, struct blasfeo_svec *sz, int zi)
 	{
 	float *x = sx->pa + xi;

--- a/auxiliary/x_aux_ext_dep_lib4.c
+++ b/auxiliary/x_aux_ext_dep_lib4.c
@@ -55,6 +55,9 @@ void ALLOCATE_STRMAT(int m, int n, struct STRMAT *sA)
 // free memory of a matrix structure
 void FREE_STRMAT(struct STRMAT *sA)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	FREE_ALIGN(sA->pA);
 	FREE_ALIGN(sA->dA);
 	return;

--- a/auxiliary/x_aux_lib.c
+++ b/auxiliary/x_aux_lib.c
@@ -91,6 +91,9 @@ void CREATE_STRVEC(int m, struct STRVEC *sa, void *memory)
 // convert a matrix into a matrix structure
 void CVT_MAT2STRMAT(int m, int n, REAL *A, int lda, struct STRMAT *sA, int ai, int aj)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int ii, jj;
 	int lda2 = sA->m;
 	REAL *pA = sA->pA + ai + aj*lda2;
@@ -117,6 +120,9 @@ void CVT_MAT2STRMAT(int m, int n, REAL *A, int lda, struct STRMAT *sA, int ai, i
 // convert and transpose a matrix into a matrix structure
 void CVT_TRAN_MAT2STRMAT(int m, int n, REAL *A, int lda, struct STRMAT *sA, int ai, int aj)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int ii, jj;
 	int lda2 = sA->m;
 	REAL *pA = sA->pA + ai + aj*lda2;
@@ -219,6 +225,9 @@ void CVT_STRVEC2VEC(int m, struct STRVEC *sa, int ai, REAL *a)
 // cast a matrix into a matrix structure
 void CAST_MAT2STRMAT(REAL *A, struct STRMAT *sA)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	sA->pA = A;
 	return;
 	}
@@ -228,6 +237,9 @@ void CAST_MAT2STRMAT(REAL *A, struct STRMAT *sA)
 // cast a matrix into the diagonal of a matrix structure
 void CAST_DIAG_MAT2STRMAT(REAL *dA, struct STRMAT *sA)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	sA->dA = dA;
 	return;
 	}
@@ -246,6 +258,9 @@ void CAST_VEC2VECMAT(REAL *a, struct STRVEC *sa)
 // copy a generic strmat into a generic strmat
 void GECP_LIBSTR(int m, int n, struct STRMAT *sA, int ai, int aj, struct STRMAT *sC, int ci, int cj)
 	{
+	// invalidate stored inverse diagonal
+	sC->use_dA = 0;
+
 	int lda = sA->m;
 	REAL *pA = sA->pA + ai + aj*lda;
 	int ldc = sC->m;
@@ -274,6 +289,9 @@ void GECP_LIBSTR(int m, int n, struct STRMAT *sA, int ai, int aj, struct STRMAT 
 // scale a generic strmat
 void GESC_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int aj)
 	{
+	// invalidate stored inverse diagonal
+	sA->use_dA = 0;
+
 	int lda = sA->m;
 	REAL *pA = sA->pA + ai + aj*lda;
 	int ii, jj;
@@ -300,6 +318,8 @@ void GESC_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int aj)
 // scale an generic strmat and copy into generic strmat
 void GECPSC_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int aj, struct STRMAT *sB, int bi, int bj)
 	{
+	// invalidate stored inverse diagonal
+	sB->use_dA = 0;
 
 	int lda = sA->m;
 	REAL *pA = sA->pA + ai + aj*lda;

--- a/blas/d_blas3_diag_lib4.c
+++ b/blas/d_blas3_diag_lib4.c
@@ -136,6 +136,10 @@ void blasfeo_dgemm_dn(int m, int n, double alpha, struct blasfeo_dvec *sA, int a
 		printf("\nblasfeo_dgemm_dn: feature not implemented yet: bi=%d, ci=%d, di=%d\n", bi, ci, di);
 		exit(1);
 		}
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	const int bs = 4;
 	int sdb = sB->cn;
 	int sdc = sC->cn;
@@ -160,6 +164,10 @@ void blasfeo_dgemm_nd(int m, int n, double alpha, struct blasfeo_dmat *sA, int a
 		printf("\nblasfeo_dgemm_nd: feature not implemented yet: ai=%d, ci=%d, di=%d\n", ai, ci, di);
 		exit(1);
 		}
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	const int bs = 4;
 	int sda = sA->cn;
 	int sdc = sC->cn;

--- a/blas/d_blas3_lib4.c
+++ b/blas/d_blas3_lib4.c
@@ -1123,9 +1123,11 @@ void dlauum_blk_nt_l_lib(int m, int n, int nv, int *rv, int *cv, double *pA, int
 // dgemm nt
 void blasfeo_dgemm_nt(int m, int n, int k, double alpha, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dmat *sB, int bi, int bj, double beta, struct blasfeo_dmat *sC, int ci, int cj, struct blasfeo_dmat *sD, int di, int dj)
 	{
-
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
 
 	const int ps = 4;
 
@@ -1139,6 +1141,9 @@ void blasfeo_dgemm_nt(int m, int n, int k, double alpha, struct blasfeo_dmat *sA
 	double *pB = sB->pA + bj*ps + (bi-bir)*sdb;
 	double *pC = sC->pA + cj*ps;
 	double *pD = sD->pA + dj*ps;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
 
 	if(ai==0 & bi==0 & ci==0 & di==0)
 		{
@@ -1290,7 +1295,6 @@ void blasfeo_dgemm_nt(int m, int n, int k, double alpha, struct blasfeo_dmat *sA
 #endif
 
 	return;
-
 	}
 
 
@@ -1298,9 +1302,11 @@ void blasfeo_dgemm_nt(int m, int n, int k, double alpha, struct blasfeo_dmat *sA
 // dgemm nn
 void blasfeo_dgemm_nn(int m, int n, int k, double alpha, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dmat *sB, int bi, int bj, double beta, struct blasfeo_dmat *sC, int ci, int cj, struct blasfeo_dmat *sD, int di, int dj)
 	{
-
 	if(m<=0 || n<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
 
 	const int ps = 4;
 
@@ -1324,7 +1330,6 @@ void blasfeo_dgemm_nn(int m, int n, int k, double alpha, struct blasfeo_dmat *sA
 	int di0 = di-air;
 	int offsetC;
 	int offsetD;
-
 	if(ci0>=0)
 		{
 		pC += ci0/ps*ps*sdd;
@@ -1744,14 +1749,18 @@ void blasfeo_dgemm_nn(int m, int n, int k, double alpha, struct blasfeo_dmat *sA
 
 
 
-// dtrsm_nn_llu
+// dtrsm_llnu
 void blasfeo_dtrsm_llnu(int m, int n, double alpha, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dmat *sB, int bi, int bj, struct blasfeo_dmat *sD, int di, int dj)
 	{
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	if(ai!=0 | bi!=0 | di!=0 | alpha!=1.0)
 		{
 		printf("\nblasfeo_dtrsm_llnu: feature not implemented yet: ai=%d, bi=%d, di=%d, alpha=%f\n", ai, bi, di, alpha);
 		exit(1);
 		}
+
 	const int ps = 4;
 	// TODO alpha
 	int sda = sA->cn;
@@ -1774,6 +1783,10 @@ void blasfeo_dtrsm_lunn(int m, int n, double alpha, struct blasfeo_dmat *sA, int
 		printf("\nblasfeo_dtrsm_lunn: feature not implemented yet: ai=%d, bi=%d, di=%d, alpha=%f\n", ai, bi, di, alpha);
 		exit(1);
 		}
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	const int ps = 4;
 	// TODO alpha
 	int sda = sA->cn;
@@ -1784,6 +1797,7 @@ void blasfeo_dtrsm_lunn(int m, int n, double alpha, struct blasfeo_dmat *sA, int
 	double *pD = sD->pA + dj*ps;
 	double *dA = sA->dA;
 	int ii;
+
 	if(ai==0 & aj==0)
 		{
 		// recompute diagonal if size of operation grows
@@ -1804,6 +1818,7 @@ void blasfeo_dtrsm_lunn(int m, int n, double alpha, struct blasfeo_dmat *sA, int
 		sA->use_dA = 0;
 		}
 	dtrsm_nn_lu_inv_lib(m, n, pA, sda, dA, pB, sdb, pD, sdd);
+
 	return;
 	}
 
@@ -1821,6 +1836,9 @@ void blasfeo_dtrsm_rltn(int m, int n, double alpha, struct blasfeo_dmat *sA, int
 		printf("\nblasfeo_dtrsm_rltn: feature not implemented yet: ai=%d, bi=%d, di=%d, alpha=%f\n", ai, bi, di, alpha);
 		exit(1);
 		}
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
 
 	const int ps = 4;
 
@@ -1997,7 +2015,6 @@ void blasfeo_dtrsm_rltn(int m, int n, double alpha, struct blasfeo_dmat *sA, int
 		}
 	return;
 #endif
-
 	}
 
 
@@ -2010,6 +2027,10 @@ void blasfeo_dtrsm_rltu(int m, int n, double alpha, struct blasfeo_dmat *sA, int
 		printf("\nblasfeo_dtrsm_rltu: feature not implemented yet: ai=%d, bi=%d, di=%d, alpha=%f\n", ai, bi, di, alpha);
 		exit(1);
 		}
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	const int ps = 4;
 	// TODO alpha
 	int sda = sA->cn;
@@ -2032,6 +2053,10 @@ void blasfeo_dtrsm_rutn(int m, int n, double alpha, struct blasfeo_dmat *sA, int
 		printf("\nblasfeo_dtrsm_rutn: feature not implemented yet: ai=%d, bi=%d, di=%d, alpha=%f\n", ai, bi, di, alpha);
 		exit(1);
 		}
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	const int ps = 4;
 	// TODO alpha
 	int sda = sA->cn;
@@ -2068,6 +2093,9 @@ void blasfeo_dtrsm_rutn(int m, int n, double alpha, struct blasfeo_dmat *sA, int
 // dtrmm_right_upper_transposed_notunit (B, i.e. the first matrix, is triangular !!!)
 void blasfeo_dtrmm_rutn(int m, int n, double alpha, struct blasfeo_dmat *sB, int bi, int bj, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dmat *sD, int di, int dj)
 	{
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	if(ai!=0 | bi!=0 | di!=0)
 		{
 		printf("\nblasfeo_dtrmm_rutn: feature not implemented yet: ai=%d, bi=%d, di=%d\n", ai, bi, di);
@@ -2105,6 +2133,10 @@ void blasfeo_dtrmm_rlnn(int m, int n, double alpha, struct blasfeo_dmat *sB, int
 
 	int di0 = di-air;
 	int offsetD;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	if(di0>=0)
 		{
 		pD += di0/ps*ps*sdd;
@@ -2264,14 +2296,12 @@ void blasfeo_dtrmm_rlnn(int m, int n, double alpha, struct blasfeo_dmat *sB, int
 		kernel_dtrmm_nn_rl_4x4_gen_lib4(n-jj, &alpha, &pA[ii*sda+jj*ps], offsetB, &pB[jj*sdb+jj*ps], sdb, offsetD, &pD[ii*sdd+jj*ps], sdd, 0, m-ii, 0, n-jj);
 		}
 	return;
-
 	}
 
 
 
 void blasfeo_dsyrk_ln(int m, int k, double alpha, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dmat *sB, int bi, int bj, double beta, struct blasfeo_dmat *sC, int ci, int cj, struct blasfeo_dmat *sD, int di, int dj)
 	{
-
 	if(m<=0)
 		return;
 
@@ -2280,6 +2310,9 @@ void blasfeo_dsyrk_ln(int m, int k, double alpha, struct blasfeo_dmat *sA, int a
 		printf("\nblasfeo_dsyrk_ln: feature not implemented yet: ai=%d, bi=%d\n", ai, bi);
 		exit(1);
 		}
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
 
 	const int ps = 4;
 
@@ -2495,7 +2528,6 @@ void blasfeo_dsyrk_ln(int m, int k, double alpha, struct blasfeo_dmat *sA, int a
 
 void blasfeo_dsyrk_ln_mn(int m, int n, int k, double alpha, struct blasfeo_dmat *sA, int ai, int aj, struct blasfeo_dmat *sB, int bi, int bj, double beta, struct blasfeo_dmat *sC, int ci, int cj, struct blasfeo_dmat *sD, int di, int dj)
 	{
-
 	if(m<=0 | n<=0)
 		return;
 
@@ -2504,6 +2536,9 @@ void blasfeo_dsyrk_ln_mn(int m, int n, int k, double alpha, struct blasfeo_dmat 
 		printf("\nblasfeo_dsyrk_ln: feature not implemented yet: ai=%d, bi=%d\n", ai, bi);
 		exit(1);
 		}
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
 
 	const int ps = 4;
 

--- a/blas/d_lapack_lib4.c
+++ b/blas/d_lapack_lib4.c
@@ -2457,9 +2457,13 @@ int blasfeo_dgeqrf_worksize(int m, int n)
 
 void blasfeo_dgeqrf(int m, int n, struct blasfeo_dmat *sC, int ci, int cj, struct blasfeo_dmat *sD, int di, int dj, void *v_work)
 	{
-	char *work = (char *) v_work;
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
+	char *work = (char *) v_work;
 	const int ps = 4;
 
 	// extract dimensions
@@ -2539,6 +2543,10 @@ void blasfeo_dgelqf(int m, int n, struct blasfeo_dmat *sC, int ci, int cj, struc
 	{
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	const int ps = 4;
 
 	// extract dimensions

--- a/blas/s_blas3_diag_lib4.c
+++ b/blas/s_blas3_diag_lib4.c
@@ -51,6 +51,9 @@ void blasfeo_sgemm_dn(int m, int n, float alpha, struct blasfeo_svec *sA, int ai
 		exit(1);
 		}
 
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	const int bs = 4;
 
 	int sdb = sB->cn;
@@ -107,6 +110,9 @@ void blasfeo_sgemm_nd(int m, int n, float alpha, struct blasfeo_smat *sA, int ai
 		printf("\nblasfeo_sgemm_nd: feature not implemented yet: ai=%d, ci=%d, di=%d\n", ai, ci, di);
 		exit(1);
 		}
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
 
 	const int bs = 4;
 

--- a/blas/s_blas3_diag_lib8.c
+++ b/blas/s_blas3_diag_lib8.c
@@ -52,6 +52,9 @@ void blasfeo_sgemm_nd(int m, int n, float alpha, struct blasfeo_smat *sA, int ai
 		exit(1);
 		}
 
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	const int bs = 8;
 
 	int sda = sA->cn;

--- a/blas/s_blas3_lib4.c
+++ b/blas/s_blas3_lib4.c
@@ -44,7 +44,6 @@ void sgemm_nt_lib(int m, int n, int k, float alpha, float *pA, int sda, float *p
 
 	if(m<=0 || n<=0)
 		return;
-	
 	const int bs = 4;
 
 	int i, j, l;
@@ -468,6 +467,10 @@ void blasfeo_sgemm_nt(int m, int n, int k, float alpha, struct blasfeo_smat *sA,
 
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	
 	const int bs = 4;
 
@@ -577,6 +580,10 @@ void blasfeo_sgemm_nn(int m, int n, int k, float alpha, struct blasfeo_smat *sA,
 		printf("\nblasfeo_sgemm_nn: feature not implemented yet: ai=%d, bi=%d, ci=%d, di=%d\n", ai, bi, ci, di);
 		exit(1);
 		}
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	const int bs = 4;
 	int sda = sA->cn;
 	int sdb = sB->cn;
@@ -589,7 +596,7 @@ void blasfeo_sgemm_nn(int m, int n, int k, float alpha, struct blasfeo_smat *sA,
 	sgemm_nn_lib(m, n, k, alpha, pA, sda, pB, sdb, beta, pC, sdc, pD, sdd); 
 	return;
 	}
-	
+
 
 
 // dtrsm_nn_llu
@@ -600,6 +607,10 @@ void blasfeo_strsm_llnu(int m, int n, float alpha, struct blasfeo_smat *sA, int 
 		printf("\nblasfeo_strsm_llnu: feature not implemented yet: ai=%d, bi=%d, di=%d, alpha=%f\n", ai, bi, di, alpha);
 		exit(1);
 		}
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	const int bs = 4;
 	// TODO alpha
 	int sda = sA->cn;
@@ -608,7 +619,7 @@ void blasfeo_strsm_llnu(int m, int n, float alpha, struct blasfeo_smat *sA, int 
 	float *pA = sA->pA + aj*bs;
 	float *pB = sB->pA + bj*bs;
 	float *pD = sD->pA + dj*bs;
-	strsm_nn_ll_one_lib(m, n, pA, sda, pB, sdb, pD, sdd); 
+	strsm_nn_ll_one_lib(m, n, pA, sda, pB, sdb, pD, sdd);
 	return;
 	}
 
@@ -622,6 +633,10 @@ void blasfeo_strsm_lunn(int m, int n, float alpha, struct blasfeo_smat *sA, int 
 		printf("\nblasfeo_strsm_lunn: feature not implemented yet: ai=%d, bi=%d, di=%d, alpha=%f\n", ai, bi, di, alpha);
 		exit(1);
 		}
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	const int bs = 4;
 	// TODO alpha
 	int sda = sA->cn;
@@ -649,7 +664,7 @@ void blasfeo_strsm_lunn(int m, int n, float alpha, struct blasfeo_smat *sA, int 
 			dA[ii] = 1.0 / dA[ii];
 		sA->use_dA = 0;
 		}
-	strsm_nn_lu_inv_lib(m, n, pA, sda, dA, pB, sdb, pD, sdd); 
+	strsm_nn_lu_inv_lib(m, n, pA, sda, dA, pB, sdb, pD, sdd);
 	return;
 	}
 
@@ -664,6 +679,9 @@ void blasfeo_strsm_rltn(int m, int n, float alpha, struct blasfeo_smat *sA, int 
 		printf("\nblasfeo_strsm_rltn: feature not implemented yet: ai=%d, bi=%d, di=%d, alpha=%f\n", ai, bi, di, alpha);
 		exit(1);
 		}
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
 
 	const int bs = 4;
 
@@ -742,6 +760,10 @@ void blasfeo_strsm_rltu(int m, int n, float alpha, struct blasfeo_smat *sA, int 
 		printf("\nblasfeo_strsm_rltu: feature not implemented yet: ai=%d, bi=%d, di=%d, alpha=%f\n", ai, bi, di, alpha);
 		exit(1);
 		}
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	const int bs = 4;
 	// TODO alpha
 	int sda = sA->cn;
@@ -764,6 +786,10 @@ void blasfeo_strsm_rutn(int m, int n, float alpha, struct blasfeo_smat *sA, int 
 		printf("\nblasfeo_strsm_rutn: feature not implemented yet: ai=%d, bi=%d, di=%d, alpha=%f\n", ai, bi, di, alpha);
 		exit(1);
 		}
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	const int bs = 4;
 	// TODO alpha
 	int sda = sA->cn;
@@ -805,6 +831,10 @@ void blasfeo_strmm_rutn(int m, int n, float alpha, struct blasfeo_smat *sB, int 
 		printf("\nblasfeo_strmm_rutn: feature not implemented yet: ai=%d, bi=%d, di=%d\n", ai, bi, di);
 		exit(1);
 		}
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	const int bs = 4;
 	int sda = sA->cn;
 	int sdb = sB->cn;
@@ -821,6 +851,9 @@ void blasfeo_strmm_rutn(int m, int n, float alpha, struct blasfeo_smat *sB, int 
 // dtrmm_right_lower_nottransposed_notunit (B, i.e. the first matrix, is triangular !!!)
 void blasfeo_strmm_rlnn(int m, int n, float alpha, struct blasfeo_smat *sB, int bi, int bj, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_smat *sD, int di, int dj)
 	{
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
 
 	const int bs = 4;
 
@@ -921,6 +954,9 @@ void blasfeo_ssyrk_ln(int m, int k, float alpha, struct blasfeo_smat *sA, int ai
 		exit(1);
 		}
 
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	const int bs = 4;
 
 	int sda = sA->cn;
@@ -981,6 +1017,9 @@ void blasfeo_ssyrk_ln_mn(int m, int n, int k, float alpha, struct blasfeo_smat *
 		printf("\nsryrk_ln_libstr: feature not implemented yet: ai=%d, bi=%d, ci=%d, di=%d\n", ai, bi, ci, di);
 		exit(1);
 		}
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
 
 	const int bs = 4;
 

--- a/blas/s_blas3_lib8.c
+++ b/blas/s_blas3_lib8.c
@@ -42,7 +42,10 @@ void blasfeo_sgemm_nt(int m, int n, int k, float alpha, struct blasfeo_smat *sA,
 
 	if(m==0 | n==0)
 		return;
-	
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 #if defined(DIM_CHECK)
 	// TODO check that sA=!sD or that if sA==sD then they do not overlap (same for sB)
 	// non-negative size
@@ -281,7 +284,10 @@ void blasfeo_sgemm_nn(int m, int n, int k, float alpha, struct blasfeo_smat *sA,
 
 	if(m==0 | n==0)
 		return;
-	
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 #if defined(DIM_CHECK)
 	// non-negative size
 	if(m<0) printf("\n****** blasfeo_sgemm_nt : m<0 : %d<0 *****\n", m);
@@ -520,6 +526,9 @@ void blasfeo_ssyrk_ln(int m, int k, float alpha, struct blasfeo_smat *sA, int ai
 		exit(1);
 		}
 
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	const int bs = 8;
 
 	int i, j;
@@ -709,6 +718,9 @@ void blasfeo_ssyrk_ln_mn(int m, int n, int k, float alpha, struct blasfeo_smat *
 		printf("\nblasfeo_ssyrk_ln_mn: feature not implemented yet: ci>0, di>0\n");
 		exit(1);
 		}
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
 
 	const int bs = 8;
 
@@ -1011,6 +1023,8 @@ void blasfeo_ssyrk_ln_mn(int m, int n, int k, float alpha, struct blasfeo_smat *
 // dtrmm_right_lower_nottransposed_notunit (B, i.e. the first matrix, is triangular !!!)
 void blasfeo_strmm_rlnn(int m, int n, float alpha, struct blasfeo_smat *sB, int bi, int bj, struct blasfeo_smat *sA, int ai, int aj, struct blasfeo_smat *sD, int di, int dj)
 	{
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
 
 	const int bs = 8;
 
@@ -1262,6 +1276,9 @@ void blasfeo_strsm_rltn(int m, int n, float alpha, struct blasfeo_smat *sA, int 
 		printf("\nblasfeo_strsm_rltn: feature not implemented yet: ai=%d, bi=%d, di=%d, alpha=%f\n", ai, bi, di, alpha);
 		exit(1);
 		}
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
 
 	const int bs = 8;
 

--- a/blas/x_blas3_diag_lib.c
+++ b/blas/x_blas3_diag_lib.c
@@ -37,6 +37,10 @@ void GEMM_L_DIAG_LIBSTR(int m, int n, REAL alpha, struct STRVEC *sA, int ai, str
 	{
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int ii, jj;
 	int ldb = sB->m;
 	int ldd = sD->m;
@@ -100,6 +104,10 @@ void GEMM_R_DIAG_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int
 	{
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int ii, jj;
 	int lda = sA->m;
 	int ldd = sD->m;

--- a/blas/x_blas3_lib.c
+++ b/blas/x_blas3_lib.c
@@ -36,6 +36,10 @@ void GEMM_NT_LIBSTR(int m, int n, int k, REAL alpha, struct STRMAT *sA, int ai, 
 	{
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int ii, jj, kk;
 	REAL 
 		c_00, c_01,
@@ -118,6 +122,10 @@ void GEMM_NN_LIBSTR(int m, int n, int k, REAL alpha, struct STRMAT *sA, int ai, 
 	{
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int ii, jj, kk;
 	REAL 
 		c_00, c_01,
@@ -200,6 +208,10 @@ void TRSM_LLNU_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int a
 	{
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int ii, jj, kk;
 	REAL
 		d_00, d_01,
@@ -322,6 +334,10 @@ void TRSM_LUNN_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int a
 	{
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int ii, jj, kk, id;
 	REAL
 		d_00, d_01,
@@ -469,6 +485,10 @@ void TRSM_RLTU_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int a
 	{
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int ii, jj, kk;
 	int lda = sA->m;
 	int ldb = sB->m;
@@ -550,6 +570,10 @@ void TRSM_RLTN_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int a
 	{
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int ii, jj, kk;
 	int lda = sA->m;
 	int ldb = sB->m;
@@ -648,6 +672,12 @@ void TRSM_RLTN_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int a
 // dtrsm_right_upper_transposed_notunit
 void TRSM_RUTN_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int aj, struct STRMAT *sB, int bi, int bj, struct STRMAT *sD, int di, int dj)
 	{
+	if(m<=0 | n<=0)
+		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	char cl = 'l';
 	char cn = 'n';
 	char cr = 'r';
@@ -782,6 +812,10 @@ void TRMM_RUTN_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int a
 	{
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int ii, jj, kk;
 	REAL
 		c_00, c_01,
@@ -869,6 +903,10 @@ void TRMM_RLNN_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int a
 	{
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int ii, jj, kk;
 	REAL 
 		c_00, c_01,
@@ -956,6 +994,10 @@ void SYRK_LN_LIBSTR(int m, int k, REAL alpha, struct STRMAT *sA, int ai, int aj,
 	{
 	if(m<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int ii, jj, kk;
 	int n = m; // TODO optimize for this case !!!!!!!!!
 	REAL
@@ -1048,6 +1090,10 @@ void SYRK_LN_MN_LIBSTR(int m, int n, int k, REAL alpha, struct STRMAT *sA, int a
 	{
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int ii, jj, kk;
 	REAL
 		c_00, c_01,
@@ -1141,6 +1187,10 @@ void SYRK_LN_MN_LIBSTR(int m, int n, int k, REAL alpha, struct STRMAT *sA, int a
 // dgemm nt
 void GEMM_NT_LIBSTR(int m, int n, int k, REAL alpha, struct STRMAT *sA, int ai, int aj, struct STRMAT *sB, int bi, int bj, REAL beta, struct STRMAT *sC, int ci, int cj, struct STRMAT *sD, int di, int dj)
 	{
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int jj;
 	char cn = 'n';
 	char ct = 't';
@@ -1184,6 +1234,10 @@ void GEMM_NT_LIBSTR(int m, int n, int k, REAL alpha, struct STRMAT *sA, int ai, 
 // dgemm nn
 void GEMM_NN_LIBSTR(int m, int n, int k, REAL alpha, struct STRMAT *sA, int ai, int aj, struct STRMAT *sB, int bi, int bj, REAL beta, struct STRMAT *sC, int ci, int cj, struct STRMAT *sD, int di, int dj)
 	{
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int jj;
 	char cn = 'n';
 	REAL *pA = sA->pA+ai+aj*sA->m;
@@ -1226,6 +1280,10 @@ void GEMM_NN_LIBSTR(int m, int n, int k, REAL alpha, struct STRMAT *sA, int ai, 
 // dtrsm_left_lower_nottransposed_unit
 void TRSM_LLNU_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int aj, struct STRMAT *sB, int bi, int bj, struct STRMAT *sD, int di, int dj)
 	{
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int jj;
 	char cl = 'l';
 	char cn = 'n';
@@ -1266,6 +1324,10 @@ void TRSM_LLNU_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int a
 // dtrsm_left_upper_nottransposed_notunit
 void TRSM_LUNN_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int aj, struct STRMAT *sB, int bi, int bj, struct STRMAT *sD, int di, int dj)
 	{
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int jj;
 	char cl = 'l';
 	char cn = 'n';
@@ -1306,6 +1368,10 @@ void TRSM_LUNN_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int a
 // dtrsm_right_lower_transposed_unit
 void TRSM_RLTU_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int aj, struct STRMAT *sB, int bi, int bj, struct STRMAT *sD, int di, int dj)
 	{
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int jj;
 	char cl = 'l';
 	char cn = 'n';
@@ -1348,6 +1414,10 @@ void TRSM_RLTU_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int a
 // dtrsm_right_lower_transposed_notunit
 void TRSM_RLTN_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int aj, struct STRMAT *sB, int bi, int bj, struct STRMAT *sD, int di, int dj)
 	{
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int jj;
 	char cl = 'l';
 	char cn = 'n';
@@ -1390,6 +1460,10 @@ void TRSM_RLTN_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int a
 // dtrsm_right_upper_transposed_notunit
 void TRSM_RUTN_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int aj, struct STRMAT *sB, int bi, int bj, struct STRMAT *sD, int di, int dj)
 	{
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int jj;
 	char cl = 'l';
 	char cn = 'n';
@@ -1432,6 +1506,10 @@ void TRSM_RUTN_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int a
 // dtrmm_right_upper_transposed_notunit (A triangular !!!)
 void TRMM_RUTN_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int aj, struct STRMAT *sB, int bi, int bj, struct STRMAT *sD, int di, int dj)
 	{
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int jj;
 	char cl = 'l';
 	char cn = 'n';
@@ -1474,6 +1552,10 @@ void TRMM_RUTN_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int a
 // dtrmm_right_lower_nottransposed_notunit (A triangular !!!)
 void TRMM_RLNN_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int aj, struct STRMAT *sB, int bi, int bj, struct STRMAT *sD, int di, int dj)
 	{
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int jj;
 	char cl = 'l';
 	char cn = 'n';
@@ -1516,6 +1598,10 @@ void TRMM_RLNN_LIBSTR(int m, int n, REAL alpha, struct STRMAT *sA, int ai, int a
 // dsyrk_lower_nortransposed (allowing for different factors => use dgemm !!!)
 void SYRK_LN_LIBSTR(int m, int k, REAL alpha, struct STRMAT *sA, int ai, int aj, struct STRMAT *sB, int bi, int bj, REAL beta, struct STRMAT *sC, int ci, int cj, struct STRMAT *sD, int di, int dj)
 	{
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int jj;
 	char cl = 'l';
 	char cn = 'n';
@@ -1573,6 +1659,10 @@ void SYRK_LN_LIBSTR(int m, int k, REAL alpha, struct STRMAT *sA, int ai, int aj,
 // dsyrk_lower_nortransposed (allowing for different factors => use dgemm !!!)
 void SYRK_LN_MN_LIBSTR(int m, int n, int k, REAL alpha, struct STRMAT *sA, int ai, int aj, struct STRMAT *sB, int bi, int bj, REAL beta, struct STRMAT *sC, int ci, int cj, struct STRMAT *sD, int di, int dj)
 	{
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int jj;
 	char cl = 'l';
 	char cn = 'n';

--- a/blas/x_lapack_lib.c
+++ b/blas/x_lapack_lib.c
@@ -37,9 +37,10 @@ void POTRF_L_LIBSTR(int m, struct STRMAT *sC, int ci, int cj, struct STRMAT *sD,
 	{
 	if(m<=0)
 		return;
+
 	int ii, jj, kk;
 	REAL
-		f_00_inv, 
+		f_00_inv,
 		f_10, f_11_inv,
 		c_00, c_01,
 		c_10, c_11;
@@ -49,6 +50,8 @@ void POTRF_L_LIBSTR(int m, struct STRMAT *sC, int ci, int cj, struct STRMAT *sD,
 	REAL *pD = sD->pA + di + dj*ldd;
 	REAL *dD = sD->dA;
 	if(di==0 & dj==0)
+		// if zero offset potrf recomputes the right values
+		// for the stored inverse diagonal of sD
 		sD->use_dA = 1;
 	else
 		sD->use_dA = 0;
@@ -177,10 +180,14 @@ void POTRF_L_MN_LIBSTR(int m, int n, struct STRMAT *sC, int ci, int cj, struct S
 	REAL *pC = sC->pA + ci + cj*ldc;
 	REAL *pD = sD->pA + di + dj*ldd;
 	REAL *dD = sD->dA;
+
 	if(di==0 & dj==0)
+		// if zero offset potrf recomputes the right values
+		// for the stored inverse diagonal of sD
 		sD->use_dA = 1;
 	else
 		sD->use_dA = 0;
+
 	jj = 0;
 	for(; jj<n-1; jj+=2)
 		{
@@ -309,6 +316,8 @@ void SYRK_POTRF_LN_LIBSTR(int m, int n, int k, struct STRMAT *sA, int ai, int aj
 	REAL *pD = sD->pA + di + dj*ldd;
 	REAL *dD = sD->dA;
 	if(di==0 & dj==0)
+		// if zero offset potrf recomputes the right values
+		// for the stored inverse diagonal of sD
 		sD->use_dA = 1;
 	else
 		sD->use_dA = 0;
@@ -465,6 +474,8 @@ void PSTRF_L_LIBSTR(int m, struct STRMAT *sC, int ci, int cj, struct STRMAT *sD,
 	REAL *pD = sD->pA + di + dj*ldd;
 	REAL *dD = sD->dA;
 	if(di==0 & dj==0)
+		// if zero offset potrf recomputes the right values
+		// for the stored inverse diagonal of sD
 		sD->use_dA = 1;
 	else
 		sD->use_dA = 0;
@@ -587,6 +598,8 @@ void GETRF_NOPIVOT_LIBSTR(int m, int n, struct STRMAT *sC, int ci, int cj, struc
 	REAL *pD = sD->pA + di + dj*ldd;
 	REAL *dD = sD->dA;
 	if(di==0 & dj==0)
+		// if zero offset potrf recomputes the right values
+		// for the stored inverse diagonal of sD
 		sD->use_dA = 1;
 	else
 		sD->use_dA = 0;
@@ -852,6 +865,8 @@ void GETRF_LIBSTR(int m, int n, struct STRMAT *sC, int ci, int cj, struct STRMAT
 	REAL *pD = sD->pA+di+dj*ldd;
 	REAL *dD = sD->dA;
 	if(di==0 & dj==0)
+		// if zero offset getrf recomputes the right values
+		// for the stored inverse diagonal of sD
 		sD->use_dA = 1;
 	else
 		sD->use_dA = 0;
@@ -1221,6 +1236,10 @@ void GEQRF_LIBSTR(int m, int n, struct STRMAT *sA, int ai, int aj, struct STRMAT
 	{
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int ii, jj, kk;
 	int lda = sA->m;
 	int ldd = sD->m;
@@ -1484,6 +1503,10 @@ void GELQF_LIBSTR(int m, int n, struct STRMAT *sA, int ai, int aj, struct STRMAT
 	{
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int ii, jj, kk;
 	int lda = sA->m;
 	int ldd = sD->m;
@@ -1746,6 +1769,10 @@ void POTRF_L_LIBSTR(int m, struct STRMAT *sC, int ci, int cj, struct STRMAT *sD,
 	{
 	if(m<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int jj;
 	char cl = 'l';
 	char cn = 'n';
@@ -1796,6 +1823,10 @@ void POTRF_L_MN_LIBSTR(int m, int n, struct STRMAT *sC, int ci, int cj, struct S
 	{
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int jj;
 	char cl = 'l';
 	char cn = 'n';
@@ -1851,6 +1882,10 @@ void SYRK_POTRF_LN_LIBSTR(int m, int n, int k, struct STRMAT *sA, int ai, int aj
 	{
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int jj;
 	char cl = 'l';
 	char cn = 'n';
@@ -1976,6 +2011,10 @@ void GETRF_NOPIVOT_LIBSTR(int m, int n, struct STRMAT *sC, int ci, int cj, struc
 	// TODO with custom level 2 LAPACK + level 3 BLAS
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int jj;
 	REAL d1 = 1.0;
 	REAL *pC = sC->pA+ci+cj*sC->m;
@@ -2014,6 +2053,10 @@ void GETRF_LIBSTR(int m, int n, struct STRMAT *sC, int ci, int cj, struct STRMAT
 	// TODO with custom level 2 LAPACK + level 3 BLAS
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int jj;
 	int tmp = m<n ? m : n;
 	REAL d1 = 1.0;
@@ -2080,6 +2123,10 @@ void GEQRF_LIBSTR(int m, int n, struct STRMAT *sC, int ci, int cj, struct STRMAT
 	{
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int jj;
 	REAL *pC = sC->pA+ci+cj*sC->m;
 	REAL *pD = sD->pA+di+dj*sD->m;
@@ -2150,6 +2197,10 @@ void GELQF_LIBSTR(int m, int n, struct STRMAT *sC, int ci, int cj, struct STRMAT
 	{
 	if(m<=0 | n<=0)
 		return;
+
+	// invalidate stored inverse diagonal of result matrix
+	sD->use_dA = 0;
+
 	int jj;
 	REAL *pC = sC->pA+ci+cj*sC->m;
 	REAL *pD = sD->pA+di+dj*sD->m;


### PR DESCRIPTION
Set use_dA = 0 in every routines which modify the matrix data.
In this case previously computed inverse diagonal will differ from
the values for the diagonal expected from the newly computed matrix.

Relative to [giaf/blasfeo/43](https://github.com/giaf/blasfeo/issues/43)